### PR TITLE
Updated to use Docker 1.0 --net=host flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Running your LAMP docker image
 
 Start your image binding the external ports 80 and 3306 in all interfaces to your container:
 
-	docker run -d -p 80:80 -p 3306:3306 tutum/lamp
+	docker run -d --net=host tutum/lamp
 
 Test your deployment:
 


### PR DESCRIPTION
using --net=host eliminates the need for a 1:1 port mapping, e.g., 80:80, and 3306:3306. the -p flag only needs used if you want to use mismatching ports, e.g., 80:8080
