### PR TITLE
Single quotes causing file not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ create a new `Dockerfile` in an empty folder with the following contents:
 	FROM tutum/lamp:latest
 	RUN rm -fr /app && git clone https://github.com/username/customapp.git /app
 	EXPOSE 80 3306
-	CMD ['/run.sh']
+	CMD ["/run.sh"]
 
 replacing `https://github.com/username/customapp.git` with your application's GIT repository.
 After that, build the new `Dockerfile`:


### PR DESCRIPTION
Running custom app from EC2 image causes /bin/sh: 1: [/run.sh]: not found when in single quotes
