### PR TITLE
Updated to Ubuntu 16.04 LTS Xenial Xerus with php7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:trusty
+FROM ubuntu:xenial
 MAINTAINER Fernando Mayo <fernando@tutum.co>, Feng Honglin <hfeng@tutum.co>
 
 # Install packages
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && \
-  apt-get -y install supervisor git apache2 libapache2-mod-php5 mysql-server php5-mysql pwgen php-apc php5-mcrypt && \
+  apt-get -y install supervisor git apache2 libapache2-mod-php mysql-server php-mysql pwgen php-apcu php-mcrypt && \
   echo "ServerName localhost" >> /etc/apache2/apache2.conf
 
 # Add image configuration and scripts
@@ -28,7 +28,7 @@ ADD apache_default /etc/apache2/sites-available/000-default.conf
 RUN a2enmod rewrite
 
 # Configure /app folder with sample app
-RUN git clone https://github.com/fermayo/hello-world-lamp.git /app
+RUN git clone -b php7 https://github.com/bitbay/hello-world-lamp.git /app
 RUN mkdir -p /app && rm -fr /var/www/html && ln -s /app /var/www/html
 
 #Environment variables to configure php

--- a/run.sh
+++ b/run.sh
@@ -3,12 +3,12 @@
 VOLUME_HOME="/var/lib/mysql"
 
 sed -ri -e "s/^upload_max_filesize.*/upload_max_filesize = ${PHP_UPLOAD_MAX_FILESIZE}/" \
-    -e "s/^post_max_size.*/post_max_size = ${PHP_POST_MAX_SIZE}/" /etc/php5/apache2/php.ini
+    -e "s/^post_max_size.*/post_max_size = ${PHP_POST_MAX_SIZE}/" /etc/php/7.0/apache2/php.ini
 if [[ ! -d $VOLUME_HOME/mysql ]]; then
     echo "=> An empty or uninitialized MySQL volume is detected in $VOLUME_HOME"
     echo "=> Installing MySQL ..."
-    mysql_install_db > /dev/null 2>&1
-    echo "=> Done!"  
+    mysqld --initialize-insecure --user=mysql > /dev/null 2>&1
+    echo "=> Done!"
     /create_mysql_admin_user.sh
 else
     echo "=> Using an existing volume of MySQL"


### PR DESCRIPTION
While trying to use this docker "receipt" with [phusion/baseimage](https://hub.docker.com/r/phusion/baseimage/), i found that it is based on xenial and was incompatible with php5, so i made an update to php7.
You can merge it into master or create a branch like "xenial" if You like.
Also, have a look at the [hello-world-lamp](https://github.com/bitbay/hello-world-lamp) fork - updated to php7.
