### PR TITLE
Remove volumes and keep mysql completely inside container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,24 +4,24 @@ MAINTAINER Fernando Mayo <fernando@tutum.co>, Feng Honglin <hfeng@tutum.co>
 # Install packages
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && \
-  apt-get -y install supervisor git apache2 libapache2-mod-php5 mysql-server php5-mysql pwgen php-apc php5-mcrypt && \
-  echo "ServerName localhost" >> /etc/apache2/apache2.conf
-
-# Add image configuration and scripts
-ADD start-apache2.sh /start-apache2.sh
-ADD start-mysqld.sh /start-mysqld.sh
-ADD run.sh /run.sh
-RUN chmod 755 /*.sh
-ADD my.cnf /etc/mysql/conf.d/my.cnf
-ADD supervisord-apache2.conf /etc/supervisor/conf.d/supervisord-apache2.conf
-ADD supervisord-mysqld.conf /etc/supervisor/conf.d/supervisord-mysqld.conf
+    apt-get -y install supervisor git apache2 libapache2-mod-php5 mysql-server php5-mysql pwgen php-apc php5-mcrypt php5-gd && \
+    php5enmod mcrypt && \
+    echo "ServerName localhost" >> /etc/apache2/apache2.conf
 
 # Remove pre-installed database
 RUN rm -rf /var/lib/mysql/*
 
-# Add MySQL utils
+# Add scripts
+ADD run.sh /run.sh
+ADD start-apache2.sh /start-apache2.sh
+ADD start-mysqld.sh /start-mysqld.sh
 ADD create_mysql_admin_user.sh /create_mysql_admin_user.sh
 RUN chmod 755 /*.sh
+
+# Add config files
+ADD my.cnf /etc/mysql/conf.d/my.cnf
+ADD supervisord-apache2.conf /etc/supervisor/conf.d/supervisord-apache2.conf
+ADD supervisord-mysqld.conf /etc/supervisor/conf.d/supervisord-mysqld.conf
 
 # config to enable .htaccess
 ADD apache_default /etc/apache2/sites-available/000-default.conf
@@ -34,9 +34,6 @@ RUN mkdir -p /app && rm -fr /var/www/html && ln -s /app /var/www/html
 #Environment variables to configure php
 ENV PHP_UPLOAD_MAX_FILESIZE 10M
 ENV PHP_POST_MAX_SIZE 10M
-
-# Add volumes for MySQL 
-VOLUME  ["/etc/mysql", "/var/lib/mysql" ]
 
 EXPOSE 80 3306
 CMD ["/run.sh"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+   Version 2.0, January 2004
+   http://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+IMAGE=moorara/lamp
+VERSION=latest
+
+build:
+	docker build -t $(IMAGE):$(VERSION) .
+
+run:
+	docker run -d -p 80:80 -p 3306:3306 $(IMAGE):$(VERSION)
+
+.PHONY: build run

--- a/apache_default
+++ b/apache_default
@@ -24,15 +24,12 @@
 
         ErrorLog ${APACHE_LOG_DIR}/error.log
 
-        # Possible values include: debug, info, notice, warn, error, crit,
-        # alert, emerg.
+        # Possible values include: debug, info, notice, warn, error, crit, alert, emerg.
         LogLevel warn
 
         CustomLog ${APACHE_LOG_DIR}/access.log combined
 
-	#
-	# Set HTTPS environment variable if we came in over secure
-	#  channel.
-	SetEnvIf x-forwarded-proto https HTTPS=on
+        # Set HTTPS environment variable if we came in over secure channel.
+        SetEnvIf x-forwarded-proto https HTTPS=on
 
 </VirtualHost>

--- a/tutum.yml
+++ b/tutum.yml
@@ -1,6 +1,0 @@
-lamp:
-  image: tutum/lamp
-  ports:
-    - 80:80
-    - 3306:3306
-    


### PR DESCRIPTION
This PR does the following three things:
- [x] Install `php5-gd` extension
- [x] Stop removing the database when container starts
- [x] Remove volumes for `mysql` and keep it completely inside the container

Having `mysql` completely inside the container lets someone to commit the container and save new image without loosing the database state. For example, I can install and configure a `Joomla` application inside the container, `commit` the changes inside container, and `run` my new image at anytime without loosing the state of database.
